### PR TITLE
fix: postsのメインページで記事が投稿した日時順でソートするように変更

### DIFF
--- a/src/pages/posts/index.astro
+++ b/src/pages/posts/index.astro
@@ -12,7 +12,10 @@ const posts: MarkdownInstance<Frontmatter>[] = await Astro.glob<Frontmatter>("..
 
 const frontmatters: Frontmatter[] = posts
   .filter((post) => post.frontmatter.isActive)
-  .map((post) => post.frontmatter);
+  .map((post) => post.frontmatter)
+  .sort((a, b) => {
+    return a.date < b.date ? 1 : -1;
+  });
 
 const metaData: Metadata = {
   ...DefaultMetadata,


### PR DESCRIPTION
## やったこと
- postsのメインページで記事が投稿した日時順でソートするように変更