### PR TITLE
fix: レイアウトの修正

### DIFF
--- a/src/components/posts/article/article_header/ArticleHeader.module.scss
+++ b/src/components/posts/article/article_header/ArticleHeader.module.scss
@@ -7,8 +7,15 @@
 
   border-bottom: 0.3rem solid var(--font-color-dark);
 
+  @media screen and (max-width: 1200px) {
+    grid-template-columns: 2fr 1fr;
+  }
+
   .tagContainer {
     display: flex;
+    flex-wrap: wrap;
+
+    width: 100%;
     gap: 0.5rem;
     grid-row: 1;
     grid-column: 1;
@@ -45,6 +52,8 @@
     @media screen and (max-width: 1200px) {
       grid-row: 1;
       grid-column: 2;
+
+      gap: 0.2rem;
 
       p {
         font-size: 1.2rem;

--- a/src/components/posts/article/article_header/link_icons/LinkIcons.module.scss
+++ b/src/components/posts/article/article_header/link_icons/LinkIcons.module.scss
@@ -1,6 +1,10 @@
 .linkIcons {
   display: flex;
   gap: 1rem;
+
+  @media screen and (max-width: 1200px) {
+    gap: 0.5rem;
+  }
 }
 
 .linkIcon {

--- a/src/components/works/imgs/Imgs.module.scss
+++ b/src/components/works/imgs/Imgs.module.scss
@@ -16,6 +16,8 @@
 
   position: relative;
 
+  overflow: hidden;
+
   img {
     width: var(--small-img-width);
     height: var(--small-img-height);
@@ -104,6 +106,10 @@
   }
 
   &:hover {
+    img {
+      scale: 1.02;
+    }
+
     .texts {
       opacity: 1;
 


### PR DESCRIPTION
## やったこと
- postsページのモバイル版でタグが多い場合にレイアウトがズレる問題の修正
- worksページで画像をホバーしたときに、画像だけを大きくするように