### PR TITLE
fix: ogpのidと画像の設定が正しくない問題を解消

### DIFF
--- a/src/pages/posts/[id]/index.astro
+++ b/src/pages/posts/[id]/index.astro
@@ -40,7 +40,7 @@ const metaData: Metadata = {
     description:
       `${frontmatter.options?.description} -${DefaultMetadata.title}` ||
       DefaultMetadata.openGraph?.description,
-    url: `${DefaultMetadata.openGraph?.url}/posts/id/${frontmatter.title}`,
+    url: `${DefaultMetadata.openGraph?.url}/posts/id/${frontmatter.number}`,
     image: frontmatter.options?.image || DefaultMetadata.openGraph?.image,
     imageAlt: `記事【${frontmatter.title}】のタイトル画像`,
   },

--- a/src/pages/posts/id/[id]/index.astro
+++ b/src/pages/posts/id/[id]/index.astro
@@ -40,7 +40,7 @@ const metaData: Metadata = {
     description:
       `${frontmatter.options?.description} -${DefaultMetadata.title}` ||
       DefaultMetadata.openGraph?.description,
-    url: `${DefaultMetadata.openGraph?.url}/posts/id/${frontmatter.title}`,
+    url: `${DefaultMetadata.openGraph?.url}/posts/id/${frontmatter.number}`,
     image: frontmatter.options?.image || DefaultMetadata.openGraph?.image,
     imageAlt: `記事【${frontmatter.title}】のタイトル画像`,
   },

--- a/src/pages/posts/tag/[tag]/index.astro
+++ b/src/pages/posts/tag/[tag]/index.astro
@@ -54,7 +54,7 @@ const metaData: Metadata = {
   openGraph: {
     ...DefaultMetadata.openGraph,
     title: `kanakanho's blog Posts tag ${tag}`,
-    url: `${DefaultMetadata.openGraph?.url}/posts/${tag}`,
+    url: `${DefaultMetadata.openGraph?.url}/posts/tag/${tag}`,
   },
 };
 ---


### PR DESCRIPTION
# やったこと

- `/posts/${id}` のときに ogp の id で URL を設定する部分に誤りがある問題を解消
- `/posts/${id}` のときに ogp の画像を設定する部分に誤りがある問題を解消
- `/posts/tag/${tag}` のリンクの誤りを修正